### PR TITLE
Fill in more of the Camera class and specific camera code, plus GIGA examples

### DIFF
--- a/examples/GigaCameraCaptureDisplayZoomPan/GigaCameraCaptureDisplayZoomPan.ino
+++ b/examples/GigaCameraCaptureDisplayZoomPan/GigaCameraCaptureDisplayZoomPan.ino
@@ -1,0 +1,166 @@
+/*
+ * This example shows how to use the Nicla Vision to capture images from the camera
+ * with a zoom window and send them over the serial port.
+ * The zoom window will move from left to right and top to bottom 
+ * in the predefined steps of pixels (ZOOM_X_STEP and ZOOM_Y_STEP).
+ * 
+ * Whenever the board sends a frame over the serial port, the blue LED will blink.
+ * 
+ * Instructions:
+ * 1. Upload this sketch to Nicla Vision.
+ * 2. Open the CameraRawBytesVisualizer.pde Processing sketch and change `useGrayScale` to `false`.
+ * 3. Adjust the serial port in the Processing sketch to match the one used by Nicla Vision.
+ * 4. Run the Processing sketch.
+ * 
+ * Initial author: Sebastian Romero @sebromero
+ */
+
+// This is a modified version that runs on the Arduino GIGA with the GC2145 camera
+// Instead of doing Serial outputs, it instead shows the image on the display.
+// Entering anything in the Serial Monitor, advances the display to the next step
+
+
+#include "arducam_dvp.h"
+#include "Arduino_H7_Video.h"
+#include "dsi.h"
+#include "SDRAM.h"
+
+#define ARDUCAM_CAMERA_GC2145
+
+#include "GC2145/gc2145.h"
+GC2145 galaxyCore;
+Camera cam(galaxyCore);
+uint32_t palette[256];
+
+
+#define IMAGE_MODE CAMERA_RGB565
+
+#define CHUNK_SIZE 512                // Size of chunks in bytes
+#define RESOLUTION CAMERA_R1600x1200  // Zoom in from the highest supported resolution
+#define ZOOM_WINDOW_RESOLUTION CAMERA_R320x240
+
+constexpr uint16_t ZOOM_WINDOW_WIDTH = 320;
+constexpr uint16_t ZOOM_WINDOW_HEIGHT = 240;
+constexpr uint16_t ZOOM_X_STEP = 100;
+constexpr uint16_t ZOOM_Y_STEP = 100;
+
+FrameBuffer fb;
+FrameBuffer outfb;
+Arduino_H7_Video Display(800, 480, GigaDisplayShield);
+
+uint32_t currentZoomX = 0;
+uint32_t currentZoomY = 0;
+uint32_t maxZoomX = 0;  // Will be calculated in setup()
+uint32_t maxZoomY = 0;  // Will be calculated in setup()
+
+
+void blinkLED(uint32_t count = 0xFFFFFFFF) {
+  pinMode(LED_BUILTIN, OUTPUT);
+
+  while (count--) {
+    digitalWrite(LED_BUILTIN, LOW);   // turn the LED on (HIGH is the voltage level)
+    delay(50);                        // wait for a second
+    digitalWrite(LED_BUILTIN, HIGH);  // turn the LED off by making the voltage LOW
+    delay(50);                        // wait for a second
+  }
+}
+
+void setup() {
+  if (!Serial && millis() < 5000) {
+    Serial.begin(115200);
+    while (!Serial)
+      ;
+  }
+
+  Serial.println("Before camera begin");
+  // Init the cam QVGA, 30FPS
+  if (!cam.begin(RESOLUTION, IMAGE_MODE, 30)) {
+    blinkLED();
+  }
+
+  Serial.println("After camera begin");
+  blinkLED(5);
+
+  // Flips the image vertically
+  cam.setVerticalFlip(true);
+
+  // Mirrors the image horizontally
+  cam.setHorizontalMirror(true);
+
+  // Calculate the max zoom window position
+  maxZoomX = cam.getResolutionWidth() - ZOOM_WINDOW_WIDTH;
+  maxZoomY = cam.getResolutionHeight() - ZOOM_WINDOW_HEIGHT;
+
+  Serial.print("Camera Width:");
+  Serial.print(cam.getResolutionWidth());
+  Serial.print(" Height:");
+  Serial.println(cam.getResolutionHeight());
+
+  Serial.print("Max Zoom X:");
+  Serial.print(maxZoomX);
+  Serial.print(" Y:");
+  Serial.println(maxZoomY);
+
+  // Set the zoom window to 0,0
+  int ret = cam.zoomTo(ZOOM_WINDOW_RESOLUTION, currentZoomX, currentZoomY);
+  Serial.print("After zoom:");
+  Serial.println(ret);
+  Display.begin();
+
+  if (IMAGE_MODE == CAMERA_GRAYSCALE) {
+    dsi_configueCLUT((uint32_t*)palette);
+  }
+  outfb.setBuffer((uint8_t*)SDRAM.malloc(1024 * 1024));
+
+  // clear the display (gives a nice black background)
+  dsi_lcdClear(0);
+  dsi_drawCurrentFrameBuffer();
+  dsi_lcdClear(0);
+  dsi_drawCurrentFrameBuffer();
+}
+
+#define HTONS(x) (((x >> 8) & 0x00FF) | ((x << 8) & 0xFF00))
+
+
+void loop() {
+  // Grab frame and write to another framebuffer
+  if (cam.grabFrame(fb, 3000) == 0) {
+
+    // double the resolution and transpose (rotate by 90 degrees) in the same step
+    // this only works if the camera feed is 320x240 and the area where we want to display is 640x480
+    for (int i = 0; i < 320; i++) {
+      for (int j = 0; j < 240; j++) {
+        if (IMAGE_MODE == CAMERA_GRAYSCALE) {
+          ((uint8_t*)outfb.getBuffer())[j * 2 + (i * 2) * 480] = ((uint8_t*)fb.getBuffer())[i + j * 320];
+          ((uint8_t*)outfb.getBuffer())[j * 2 + (i * 2) * 480 + 1] = ((uint8_t*)fb.getBuffer())[i + j * 320];
+          ((uint8_t*)outfb.getBuffer())[j * 2 + (i * 2 + 1) * 480] = ((uint8_t*)fb.getBuffer())[i + j * 320];
+          ((uint8_t*)outfb.getBuffer())[j * 2 + (i * 2 + 1) * 480 + 1] = ((uint8_t*)fb.getBuffer())[i + j * 320];
+        } else {
+          ((uint16_t*)outfb.getBuffer())[j * 2 + (i * 2) * 480] = HTONS(((uint16_t*)fb.getBuffer())[i + j * 320]);
+          ((uint16_t*)outfb.getBuffer())[j * 2 + (i * 2) * 480 + 1] = HTONS(((uint16_t*)fb.getBuffer())[i + j * 320]);
+          ((uint16_t*)outfb.getBuffer())[j * 2 + (i * 2 + 1) * 480] = HTONS(((uint16_t*)fb.getBuffer())[i + j * 320]);
+          ((uint16_t*)outfb.getBuffer())[j * 2 + (i * 2 + 1) * 480 + 1] = HTONS(((uint16_t*)fb.getBuffer())[i + j * 320]);
+        }
+      }
+    }
+    dsi_lcdDrawImage((void*)outfb.getBuffer(), (void*)dsi_getCurrentFrameBuffer(), 480, 640, IMAGE_MODE == CAMERA_GRAYSCALE ? DMA2D_INPUT_L8 : DMA2D_INPUT_RGB565);
+    dsi_drawCurrentFrameBuffer();
+  } else {
+    blinkLED(20);
+  }
+
+  if (Serial.available()) {
+    while (Serial.read() != -1) {}
+
+    currentZoomX += ZOOM_X_STEP;
+
+    if (currentZoomX > maxZoomX) {
+      currentZoomX = 0;
+      currentZoomY += ZOOM_Y_STEP;
+      if (currentZoomY > maxZoomY) {
+        currentZoomY = 0;
+      }
+    }
+    cam.zoomTo(ZOOM_WINDOW_RESOLUTION, currentZoomX, currentZoomY);
+  }
+}

--- a/examples/GigaCameraDisplayDirect/GigaCameraDisplayDirect.ino
+++ b/examples/GigaCameraDisplayDirect/GigaCameraDisplayDirect.ino
@@ -1,0 +1,196 @@
+//=============================================================================
+// Simple Camera to Arduino Giga Display SHield display.  
+// This sketch only uses one frame buffer and if the image is > QVGA it
+// truncates the image to 480x480
+//=============================================================================
+#include "arducam_dvp.h"
+#include "Arduino_H7_Video.h"
+#include "dsi.h"
+#include "SDRAM.h"
+
+//=============================================================================
+// Define which camera - uncomment only one.
+//=============================================================================
+//#define ARDUCAM_CAMERA_HM01B0
+//#define ARDUCAM_CAMERA_HM0360
+#define ARDUCAM_CAMERA_OV767X
+//#define ARDUCAM_CAMERA_GC2145
+
+//=============================================================================
+// Define which resolution
+//=============================================================================
+
+  // CAMERA_R160x120     = 0,   /* QQVGA Resolution   */
+  // CAMERA_R320x240     = 1,   /* QVGA Resolution    */
+  // CAMERA_R320x320     = 2,   /* 320x320 Resolution */
+  // CAMERA_R640x480     = 3,   /* VGA                */
+  // CAMERA_R800x600     = 5,   /* SVGA               */
+  // CAMERA_R1600x1200   = 6,   /* UXGA               */
+  // CAMERA_RMAX                /* Sentinel value */
+#define RESOLUTION CAMERA_R640x480
+
+//=============================================================================
+#ifdef ARDUCAM_CAMERA_HM01B0
+#include "Himax_HM01B0/himax.h"
+HM01B0 himax;
+Camera cam(himax);
+#define IMAGE_MODE CAMERA_GRAYSCALE
+
+#elif defined(ARDUCAM_CAMERA_HM0360)
+#include "Himax_HM0360/hm0360.h"
+HM0360 himax;
+Camera cam(himax);
+#define IMAGE_MODE CAMERA_GRAYSCALE
+
+#elif defined(ARDUCAM_CAMERA_OV767X)
+#include "OV7670/ov767x.h"
+// OV7670 ov767x;
+OV7675 ov767x;
+Camera cam(ov767x);
+#define IMAGE_MODE CAMERA_RGB565
+
+#elif defined(ARDUCAM_CAMERA_GC2145)
+#include "GC2145/gc2145.h"
+GC2145 galaxyCore;
+Camera cam(galaxyCore);
+#define IMAGE_MODE CAMERA_RGB565
+#endif
+
+// The buffer used to capture the frame
+FrameBuffer fb;
+
+// The buffer used to rotate and resize the frame
+Arduino_H7_Video Display(800, 480, GigaDisplayShield);
+
+void blinkLED(uint32_t count = 0xFFFFFFFF) {
+  pinMode(LED_BUILTIN, OUTPUT);
+  while (count--) {
+    digitalWrite(LED_BUILTIN, LOW);   // turn the LED on (HIGH is the voltage level)
+    delay(50);                        // wait for a second
+    digitalWrite(LED_BUILTIN, HIGH);  // turn the LED off by making the voltage LOW
+    delay(50);                        // wait for a second
+  }
+}
+
+uint32_t palette[256];
+
+//#define CAMERA_WIDTH 640
+//#define CAMERA_HEIGHT 480
+
+uint32_t CAMERA_WIDTH;
+uint32_t CAMERA_HEIGHT;
+
+
+void setup() {
+  // Init the cam QVGA, 30FPS
+  while (!Serial && millis() < 4000) {}
+  Serial.begin(115200);
+  cam.debug(Serial);
+
+  
+  Serial.println("Giga Camera shield direct start");
+  if (!cam.begin(RESOLUTION, IMAGE_MODE, 15)) {
+    Serial.println("Camera Begin failed!!!");
+    blinkLED();
+  }
+  CAMERA_WIDTH = cam.getResolutionWidth();
+  CAMERA_HEIGHT = cam.getResolutionHeight();
+
+  Serial.print("Camera Width:");
+  Serial.print(CAMERA_WIDTH, DEC);
+  Serial.print(" Height:");
+  Serial.print(CAMERA_HEIGHT, DEC);
+
+  uint32_t buffer_size = cam.frameSize();
+  Serial.print(" Buffer Size:");
+  Serial.println(buffer_size);
+
+  cam.printRegs();
+
+#if defined(ARDUCAM_CAMERA_HM0360) || defined(ARDUCAM_CAMERA_HM01B0)
+  cam.setVerticalFlip(true);
+  // Mirrors the image horizontally
+  cam.setHorizontalMirror(true);
+#endif
+  // Setup the palette to convert 8 bit greyscale to 32bit greyscale
+  for (int i = 0; i < 256; i++) {
+    palette[i] = 0xFF000000 | (i << 16) | (i << 8) | i;
+  }
+
+
+  Display.begin();
+
+  if (IMAGE_MODE == CAMERA_GRAYSCALE) {
+    dsi_configueCLUT((uint32_t *)palette);
+  }
+  // big enough for full screen.
+  Serial.println("Try malloc to allocate buffer");
+  Serial.flush();
+  uint8_t *fb_buf = (uint8_t *)malloc(buffer_size + 32);
+  if (fb_buf == nullptr) {
+    Serial.println("Falled, try SDRAM.malloc");
+    fb_buf = (uint8_t *)SDRAM.malloc(buffer_size + 32);
+    if (fb_buf == nullptr) {
+      Serial.println("*** failed ***");
+      blinkLED();
+    }
+  }
+  fb_buf = (uint8_t *)((((uint32_t)fb_buf) + 32) & 0xffffffe0l);
+  Serial.print("FB Buffer: ");
+  Serial.println((uint32_t)fb_buf, HEX);
+
+  fb.setBuffer(fb_buf);
+
+  // clear the display (gives a nice black background)
+  dsi_lcdClear(0);
+  dsi_drawCurrentFrameBuffer();
+  dsi_lcdClear(0);
+  dsi_drawCurrentFrameBuffer();
+}
+
+inline uint16_t HTONS(uint16_t x) {
+  return (((x >> 8) & 0x00FF) | ((x << 8) & 0xFF00));
+}
+
+void loop() {
+
+  // Grab frame and write to another framebuffer
+  if (cam.grabFrame(fb, 3000) == 0) {
+
+    // double the resolution and transpose (rotate by 90 degrees) in the same step
+    // this only works if the camera feed is 320x240 and the area where we want to display is 640x480
+    SCB_CleanInvalidateDCache();
+    if (CAMERA_WIDTH < 480) {
+      if (IMAGE_MODE == CAMERA_RGB565) {
+        uint16_t *frame_in = (uint16_t *)fb.getBuffer();
+        for (uint32_t ii = 0; ii < (CAMERA_WIDTH * CAMERA_HEIGHT); ii++) frame_in[ii] = HTONS(frame_in[ii]);
+      }
+      dsi_lcdDrawImage((void *)fb.getBuffer(), (void *)dsi_getCurrentFrameBuffer(), CAMERA_WIDTH, CAMERA_HEIGHT, IMAGE_MODE == CAMERA_GRAYSCALE ? DMA2D_INPUT_L8 : DMA2D_INPUT_RGB565);
+    } else {
+      if (IMAGE_MODE == CAMERA_GRAYSCALE) {
+        uint8_t *frame_in = (uint8_t *)fb.getBuffer();
+        for (int y = 0; y < 480; y++) {
+          for (int x = 0; x < 480; x++) {
+            frame_in[y * 480 + x] = frame_in[y * CAMERA_WIDTH + x];
+          }
+        }
+      } else {
+        uint16_t *frame_in = (uint16_t *)fb.getBuffer();
+        for (int y = 0; y < 480; y++) {
+          for (int x = 0; x < 480; x++) {
+            frame_in[y * 480 + x] = HTONS(frame_in[y * CAMERA_WIDTH + x]);
+          }
+        }
+      }
+      dsi_lcdDrawImage((void *)fb.getBuffer(), (void *)dsi_getCurrentFrameBuffer(), 480, 480, IMAGE_MODE == CAMERA_GRAYSCALE ? DMA2D_INPUT_L8 : DMA2D_INPUT_RGB565);
+    }
+    dsi_drawCurrentFrameBuffer();
+  } else {
+    blinkLED(20);
+    static uint8_t error_count = 10;
+    if (error_count) {
+      Serial.println("Failed to read frame");
+      error_count--;
+    }
+  }
+}

--- a/src/GC2145/gc2145.h
+++ b/src/GC2145/gc2145.h
@@ -25,14 +25,18 @@ class GC2145: public ImageSensor {
    private:
         int setWindow(uint16_t reg, uint16_t x, uint16_t y, uint16_t w, uint16_t h);
         Stream *_debug;
-        arduino::MbedI2C *_i2c;
-        int regWrite(uint8_t dev_addr, uint16_t reg_addr, uint8_t reg_data, bool wide_addr = false);
-        uint8_t regRead(uint8_t dev_addr, uint16_t reg_addr, bool wide_addr = false);
+        WIRECLASS *_i2c;
+//        int regWrite(uint8_t dev_addr, uint16_t reg_addr, uint8_t reg_data, bool wide_addr = false);
+//        uint8_t regRead(uint8_t dev_addr, uint16_t reg_addr, bool wide_addr = false);
         bool vertical_flip_state = false;
         bool horizontal_mirror_state = false;
 
+   public: // temporary to experiment
+        int regWrite(uint8_t dev_addr, uint16_t reg_addr, uint8_t reg_data, bool wide_addr = false);
+        uint8_t regRead(uint8_t dev_addr, uint16_t reg_addr, bool wide_addr = false);
+
    public:
-        GC2145(arduino::MbedI2C &i2c = CameraWire);
+        GC2145(WIRECLASS &i2c = CameraWire);
         int init();
         int reset();
         int getID() { return GC2145_I2C_ADDR; };
@@ -49,6 +53,7 @@ class GC2145: public ImageSensor {
         int motionDetected() { return 0; };
         int setVerticalFlip(bool flip_enable);
         int setHorizontalMirror(bool mirror_enable);
+        uint8_t printRegs();
         void debug(Stream &stream);
 };
 

--- a/src/Himax_HM01B0/himax.h
+++ b/src/Himax_HM01B0/himax.h
@@ -8,7 +8,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See thea
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
@@ -20,20 +20,24 @@
 #define __HIMAX_H
 
 #include "arducam_dvp.h"
+#if defined(ARDUINO_ARCH_MBED)
 #include "drivers/InterruptIn.h"
+#endif
 
 class HM01B0: public ImageSensor {
    private:
         Stream *_debug;
-        arduino::MbedI2C *_i2c;
+        WIRECLASS *_i2c;
+#if defined(ARDUINO_ARCH_MBED)
         mbed::InterruptIn md_irq;
+#endif
         md_callback_t _md_callback;
         void irqHandler();
         int regWrite(uint8_t dev_addr, uint16_t reg_addr, uint8_t reg_data, bool wide_addr = false);
         uint8_t regRead(uint8_t dev_addr, uint16_t reg_addr, bool wide_addr = false);
 
    public:
-        HM01B0(arduino::MbedI2C &i2c = CameraWire);
+        HM01B0(WIRECLASS &i2c = CameraWire);
         int init();
         int reset();
         int getID() { return HM01B0_I2C_ADDR; };

--- a/src/Himax_HM0360/hm0360.cpp
+++ b/src/Himax_HM0360/hm0360.cpp
@@ -160,6 +160,154 @@
 #define         AE_CTRL_ENABLE                  0x00
 #define         AE_CTRL_DISABLE                 0x01
 
+#define HM0360_DEBUG
+#ifdef HM0360_DEBUG
+typedef struct {
+  const char *reg_name;
+  uint16_t reg;
+} HIMAX_REG_TO_NAME_t;
+
+static const HIMAX_REG_TO_NAME_t ov_reg_name_table[] =
+{
+    {"MODEL_ID_H", 0x0000},
+    {"MODEL_ID_L", 0x0001},
+    {"SILICON_REV", 0x0002},
+    {"FRAME_COUNT_H", 0x0005},
+    {"FRAME_COUNT_L", 0x0006},
+    {"PIXEL_ORDER", 0x0007},
+    {"MODE_SELECT", 0x0100},
+    {"IMG_ORIENTATION", 0x0101},
+    {"EMBEDDED_LINE_EN", 0x0102},
+    {"SW_RESET", 0x0103},
+    {"COMMAND_UPDATE", 0x0104},
+    {"INTEGRATION_H", 0x0202},
+    {"INTEGRATION_L", 0x0203},
+    {"ANALOG_GAIN", 0x0205},
+    {"DIGITAL_GAIN_H", 0x020E},
+    {"DIGITAL_GAIN_L", 0x020F},
+    {"PLL1_CONFIG", 0x0300},
+    {"PLL2_CONFIG", 0x0301},
+    {"PLL3_CONFIG", 0x0302},
+    {"FRAME_LEN_LINES_H", 0x0340},
+    {"FRAME_LEN_LINES_L", 0x0341},
+    {"LINE_LEN_PCK_H", 0x0342},
+    {"LINE_LEN_PCK_L", 0x0343},
+    {"MONO_MODE", 0x0370},
+    {"MONO_MODE_ISP", 0x0371},
+    {"MONO_MODE_SEL", 0x0372},
+    {"H_SUBSAMPLE", 0x0380},
+    {"V_SUBSAMPLE", 0x0381},
+    {"BINNING_MODE", 0x0382},
+    {"TEST_PATTERN_MODE", 0x0601},
+    {"BLC_TGT", 0x1004},
+    {"BLC2_TGT", 0x1009},
+    {"MONO_CTRL", 0x100A},
+    {"OPFM_CTRL", 0x1014},
+    {"CMPRS_CTRL", 0x102F},
+    {"CMPRS_01", 0x1030},
+    {"CMPRS_02", 0x1031},
+    {"CMPRS_03", 0x1032},
+    {"CMPRS_04", 0x1033},
+    {"CMPRS_05", 0x1034},
+    {"CMPRS_06", 0x1035},
+    {"CMPRS_07", 0x1036},
+    {"CMPRS_08", 0x1037},
+    {"CMPRS_09", 0x1038},
+    {"CMPRS_10", 0x1039},
+    {"CMPRS_11", 0x103A},
+    {"CMPRS_12", 0x103B},
+    {"CMPRS_13", 0x103C},
+    {"CMPRS_14", 0x103D},
+    {"CMPRS_15", 0x103E},
+    {"CMPRS_16", 0x103F},
+    {"AE_CTRL", 0x2000},
+    {"AE_CTRL1", 0x2001},
+    {"CNT_ORGH_H", 0x2002},
+    {"CNT_ORGH_L", 0x2003},
+    {"CNT_ORGV_H", 0x2004},
+    {"CNT_ORGV_L", 0x2005},
+    {"CNT_STH_H", 0x2006},
+    {"CNT_STH_L", 0x2007},
+    {"CNT_STV_H", 0x2008},
+    {"CNT_STV_L", 0x2009},
+    {"CTRL_PG_SKIPCNT", 0x200A},
+    {"BV_WIN_WEIGHT_EN", 0x200D},
+    {"MAX_INTG_H", 0x2029},
+    {"MAX_INTG_L", 0x202A},
+    {"MAX_AGAIN", 0x202B},
+    {"MAX_DGAIN_H", 0x202C},
+    {"MAX_DGAIN_L", 0x202D},
+    {"MIN_INTG", 0x202E},
+    {"MIN_AGAIN", 0x202F},
+    {"MIN_DGAIN", 0x2030},
+    {"T_DAMPING", 0x2031},
+    {"N_DAMPING", 0x2032},
+    {"ALC_TH", 0x2033},
+    {"AE_TARGET_MEAN", 0x2034},
+    {"AE_MIN_MEAN", 0x2035},
+    {"AE_TARGET_ZONE", 0x2036},
+    {"CONVERGE_IN_TH", 0x2037},
+    {"CONVERGE_OUT_TH", 0x2038},
+    {"FS_CTRL", 0x203B},
+    {"FS_60HZ_H", 0x203C},
+    {"FS_60HZ_L", 0x203D},
+    {"FS_50HZ_H", 0x203E},
+    {"FS_50HZ_L", 0x203F},
+    {"FRAME_CNT_TH", 0x205B},
+    {"AE_MEAN", 0x205D},
+    {"AE_CONVERGE", 0x2060},
+    {"AE_BLI_TGT", 0x2070},
+    {"PULSE_MODE", 0x2061},
+    {"PULSE_TH_H", 0x2062},
+    {"PULSE_TH_L", 0x2063},
+    {"INT_INDIC", 0x2064},
+    {"INT_CLEAR", 0x2065},
+    {"MD_CTRL", 0x2080},
+    {"ROI_START_END_V", 0x2081},
+    {"ROI_START_END_H", 0x2082},
+    {"MD_TH_MIN", 0x2083},
+    {"MD_TH_STR_L", 0x2084},
+    {"MD_TH_STR_H", 0x2085},
+    {"MD_LIGHT_COEF", 0x2099},
+    {"MD_BLOCK_NUM_TH", 0x209B},
+    {"MD_LATENCY", 0x209C},
+    {"MD_LATENCY_TH", 0x209D},
+    {"MD_CTRL1", 0x209E},
+    {"PMU_CFG_3", 0x3024},
+    {"PMU_CFG_4", 0x3025},
+    {"WIN_MODE", 0x3030},
+    {"VSYNC_FRONT", 0x3094},
+    {"VSYNC_END", 0x3095},
+    {"HSYNC_FRONT_H", 0x3096},
+    {"HSYNC_FRONT_L", 0x3097},
+    {"HSYNC_END_H", 0x3098},
+    {"HSYNC_END_L", 0x3099},
+    {"READ_PU_FRONT", 0x309A},
+    {"READ_PU_End", 0x309B},
+    {"EARLY_INT_EN", 0x309C},
+    {"PCLKO_GATED_EN", 0x309E},
+    {"PCLKO_FRAME_FRONT", 0x309F},
+    {"PCLKO_FRAME_END", 0x30A0},
+    {"PCLKO_LINE_FRONT_H", 0x30A1},
+    {"PCLKO_LINE_FRONT_L", 0x30A2},
+    {"PCLKO_LINE_END_H", 0x30A3},
+    {"PCLKO_LINE_END_L", 0x30A4},
+    {"OUTPUT_EN", 0x30A5},
+    {"FRAME_OUTPUT_EN", 0x30A8},
+    {"MULTI_CAMERA_CONFIG", 0x30A9},
+    {"MULTI_CAMERA_TUNE_H", 0x30AA},
+    {"MULTI_CAMERA_TUNE_L", 0x30AB},
+    {"ANA_REGISTER_03", 0x310E},
+    {"ANA_REGISTER_04", 0x310F},
+    {"ANA_REGISTER_05", 0x3110},
+    {"ANA_REGISTER_06", 0x3111},
+    {"PAD_REGISTER_07", 0x3112},
+    {"PLL_POST_DIV_D", 0x3128},
+};
+
+#endif
+
+
 /**
  * @}
  */
@@ -544,9 +692,11 @@ static const uint16_t himax_qqvga_regs[][2] = {
     {0x0000,                0x00},
 };
 
-HM0360::HM0360(arduino::MbedI2C &i2c) : 
+HM0360::HM0360(WIRECLASS &i2c) : 
     _i2c(&i2c),
+#if defined(ARDUINO_ARCH_MBED)
     md_irq(PC_15),
+#endif
     _md_callback(NULL)
 {
 }
@@ -588,17 +738,23 @@ int HM0360::reset()
 
 int HM0360::setVerticalFlip(bool flip_enable)
 {
-  return -1;
+    uint8_t reg = regRead(HM0360_I2C_ADDR, IMG_ORIENTATION, true);
+    if (flip_enable) reg |= 2;
+    else reg &= 0xFD;
+    return regWrite(HM0360_I2C_ADDR, IMG_ORIENTATION, reg, true);
 }
 
 int HM0360::setHorizontalMirror(bool mirror_enable)
 {
-  return -1;
+    uint8_t reg = regRead(HM0360_I2C_ADDR, IMG_ORIENTATION, true);
+    if (mirror_enable) reg |= 1;
+    else reg &= 0xFE;
+    return regWrite(HM0360_I2C_ADDR, IMG_ORIENTATION, reg, true);
 }
 
 int HM0360::setResolution(int32_t resolution)
 {
-    setResolutionWithZoom(resolution, resolution, 0, 0);
+    return setResolutionWithZoom(resolution, resolution, 0, 0);
 }
 
 int HM0360::setResolutionWithZoom(int32_t resolution, int32_t zoom_resolution, uint32_t zoom_x, uint32_t zoom_y)
@@ -720,11 +876,13 @@ int HM0360::setMotionDetectionWindow(uint32_t x, uint32_t y, uint32_t w, uint32_
 
 int HM0360::enableMotionDetection(md_callback_t callback)
 {
+#if defined(ARDUINO_ARCH_MBED)
     md_irq.rise(0);
     _md_callback = callback;
     md_irq.rise(mbed::Callback<void()>(this, &HM0360::irqHandler));
     md_irq.enable_irq();
-
+#else
+#endif    
     int ret = clearMotionDetection();
     uint8_t md_ctrl = regRead(HM0360_I2C_ADDR, MD_CTRL, true);
     ret |= regWrite(HM0360_I2C_ADDR, MD_CTRL, (md_ctrl & 0xFE) | 1, true);
@@ -761,12 +919,27 @@ int HM0360::clearMotionDetection()
 
 uint8_t HM0360::printRegs()
 {
-    for (uint32_t i=0; himax_default_regs[i][0]; i++) {
-        printf("0x%04X: 0x%02X  0x%02X \n",
-                himax_default_regs[i][0],
-                himax_default_regs[i][1],
-                regRead(HM0360_I2C_ADDR, himax_default_regs[i][0], true));
+    if (_debug == nullptr) return -1;
+    
+    _debug->println("\n*** Camera Registers ***");
+
+    // Now lets print out like we have on Teeny version
+    printf("\n*** Camera Registers ***\n");
+    for (uint16_t ii = 0; ii < (sizeof(ov_reg_name_table)/sizeof(ov_reg_name_table[0])); ii++) {
+
+        uint8_t reg_value = regRead(HM0360_I2C_ADDR, ov_reg_name_table[ii].reg, true);
+        
+        _debug->print("(0x"); 
+        _debug->print(ii, HEX);
+        _debug->print("): (0x"); 
+        _debug->print(reg_value, HEX);
+        _debug->print(" - ");
+        _debug->print(reg_value, DEC);
+        _debug->print(")\t// ");
+        _debug->println(ov_reg_name_table[ii].reg_name);
     }
+
+
     return 0;
 }
 

--- a/src/Himax_HM0360/hm0360.h
+++ b/src/Himax_HM0360/hm0360.h
@@ -20,20 +20,24 @@
 #define __HIMAX_H
 
 #include "arducam_dvp.h"
+#if defined(ARDUINO_ARCH_MBED)
 #include "drivers/InterruptIn.h"
+#endif
 
 class HM0360: public ImageSensor {
    private:
         Stream *_debug;
-        arduino::MbedI2C *_i2c;
+        WIRECLASS *_i2c;
+#if defined(ARDUINO_ARCH_MBED)
         mbed::InterruptIn md_irq;
+#endif
         md_callback_t _md_callback;
         void irqHandler();
         int regWrite(uint8_t dev_addr, uint16_t reg_addr, uint8_t reg_data, bool wide_addr = false);
         uint8_t regRead(uint8_t dev_addr, uint16_t reg_addr, bool wide_addr = false);
 
    public:
-        HM0360(arduino::MbedI2C &i2c = CameraWire);
+        HM0360(WIRECLASS &i2c = CameraWire);
         int init();
         int reset();
         int getID() { return HM0360_I2C_ADDR; };

--- a/src/OV7670/ov7670.cpp
+++ b/src/OV7670/ov7670.cpp
@@ -657,7 +657,7 @@ const uint8_t OV7670::qqvga_regs[][2] = {
     { 0XFF,         0XFF },
 };
 
-OV7670::OV7670(arduino::MbedI2C &i2c) : 
+OV7670::OV7670(WIRECLASS &i2c) : 
     _i2c(&i2c)
 {
 }
@@ -710,6 +710,7 @@ int OV7670::setHorizontalMirror(bool mirror_enable)
 int OV7670::setResolution(int32_t resolution)
 {
     setResolutionWithZoom(resolution, resolution, 0, 0);
+    return 0;
 }
 
 int OV7670::setResolutionWithZoom(int32_t resolution, int32_t zoom_resolution, uint32_t zoom_x, uint32_t zoom_y)
@@ -767,8 +768,265 @@ int OV7670::setPixelFormat(int32_t pixformat)
     return ret;
 }
 
+#define OV767X_DEBUG
+#ifdef OV767X_DEBUG
+typedef struct {
+  const char *reg_name;
+  unsigned char reg;
+} OVREG_TO_NAME_t;
+
+static const OVREG_TO_NAME_t ov_reg_name_table[] =
+{
+    {"GAIN", 0x00},               //< AGC gain bits 7:0 (9:8 in VREF)
+    {"BLUE", 0x01},               //< AWB blue channel gain
+    {"RED", 0x02},                //< AWB red channel gain
+    {"VREF", 0x03},               //< Vert frame control bits
+    {"COM1", 0x04},               //< Common control 1
+    {"BAVE", 0x05},               //< U/B average level
+    {"GbAVE", 0x06},              //< Y/Gb average level
+    {"AECHH", 0x07},              //< Exposure value - AEC 15:10 bits
+    {"RAVE", 0x08},               //< V/R average level
+    {"COM2", 0x09},               //< Common control 2
+    {"PID", 0x0A},                //< Product ID MSB (read-only)
+    {"VER", 0x0B},                //< Product ID LSB (read-only)
+    {"COM3", 0x0C},               //< Common control 3
+    {"COM4", 0x0D},               //< Common control 4
+    {"COM5", 0x0E},               //< Common control 5
+    {"COM6", 0x0F},               //< Common control 6
+    {"AECH", 0x10},               //< Exposure value 9:2
+    {"CLKRC", 0x11},              //< Internal clock
+    {"COM7", 0x12},               //< Common control 7
+    {"COM8", 0x13},               //< Common control 8
+    {"COM9", 0x14},               //< Common control 9 - max AGC value
+    {"COM10", 0x15},              //< Common control 10
+    {"*RSVD*", 0x16},
+    {"HSTART", 0x17},             //< Horiz frame start high bits
+    {"HSTOP", 0x18},              //< Horiz frame end high bits
+    {"VSTART", 0x19},             //< Vert frame start high bits
+    {"VSTOP", 0x1A},              //< Vert frame end high bits
+    {"PSHFT", 0x1B},              //< Pixel delay select
+    {"MIDH", 0x1C},               //< Manufacturer ID high byte
+    {"MIDL", 0x1D},               //< Manufacturer ID low byte
+    {"MVFP", 0x1E},               //< Mirror / vert-flip enable
+    {"LAEC", 0x1F},               //< Reserved
+    {"ADCCTR0", 0x20},            //< ADC control
+    {"ADCCTR1", 0x21},            //< Reserved
+    {"ADCCTR2", 0x22},            //< Reserved
+    {"ADCCTR3", 0x23},            //< Reserved
+    {"AEW", 0x24},                //< AGC/AEC upper limit
+    {"AEB", 0x25},                //< AGC/AEC lower limit
+    {"VPT", 0x26},                //< AGC/AEC fast mode op region
+    {"BBIAS", 0x27},              //< B channel signal output bias
+    {"GbBIAS", 0x28},             //< Gb channel signal output bias
+    {"*RSVD*", 0x29},
+    {"EXHCH", 0x2A},              //< Dummy pixel insert MSB
+    {"EXHCL", 0x2B},              //< Dummy pixel insert LSB
+    {"RBIAS", 0x2C},              //< R channel signal output bias
+    {"ADVFL", 0x2D},              //< Insert dummy lines MSB
+    {"ADVFH", 0x2E},              //< Insert dummy lines LSB
+    {"YAVE", 0x2F},               //< Y/G channel average value
+    {"HSYST", 0x30},              //< HSYNC rising edge delay
+    {"HSYEN", 0x31},              //< HSYNC falling edge delay
+    {"HREF", 0x32},               //< HREF control
+    {"CHLF", 0x33},               //< Array current control
+    {"ARBLM", 0x34},              //< Array ref control - reserved
+    {"*RSVD*", 0x35},
+    {"*RSVD*", 0x36},
+    {"ADC", 0x37},                //< ADC control - reserved
+    {"ACOM", 0x38},               //< ADC & analog common - reserved
+    {"OFON", 0x39},               //< ADC offset control - reserved
+    {"TSLB", 0x3A},               //< Line buffer test option
+    {"COM11", 0x3B},              //< Common control 11
+    {"COM12", 0x3C},              //< Common control 12
+    {"COM13", 0x3D},              //< Common control 13
+    {"COM14", 0x3E},              //< Common control 14
+    {"EDGE", 0x3F},               //< Edge enhancement adjustment
+    {"COM15", 0x40},              //< Common control 15
+    {"COM16", 0x41},              //< Common control 16
+    {"COM17", 0x42},              //< Common control 17
+    {"AWBC1", 0x43},              //< Reserved
+    {"AWBC2", 0x44},              //< Reserved
+    {"AWBC3", 0x45},              //< Reserved
+    {"AWBC4", 0x46},              //< Reserved
+    {"AWBC5", 0x47},              //< Reserved
+    {"AWBC6", 0x48},              //< Reserved
+    {"*RSVD*", 0x49},
+    {"*RSVD*", 0x4A},
+    {"REG4B", 0x4B},              //< UV average enable
+    {"DNSTH", 0x4C},              //< De-noise strength
+    {"DM_POS", 0x4D},             // Dummy row position
+    {"*RSVD*", 0x4E},
+    {"MTX1", 0x4F},               //< Matrix coefficient 1
+    {"MTX2", 0x50},               //< Matrix coefficient 2
+    {"MTX3", 0x51},               //< Matrix coefficient 3
+    {"MTX4", 0x52},               //< Matrix coefficient 4
+    {"MTX5", 0x53},               //< Matrix coefficient 5
+    {"MTX6", 0x54},               //< Matrix coefficient 6
+    {"BRIGHT", 0x55},             //< Brightness control
+    {"CONTRAS", 0x56},            //< Contrast control
+    {"CONTRAS_CENTER", 0x57},     //< Contrast center
+    {"MTXS", 0x58},               //< Matrix coefficient sign
+    {"AWBC7", 0x59},              //< AWB Control
+    {"AWBC8", 0x5A},              //< AWB control
+    {"AWBC9", 0x5B},              //< AWB control
+    {"AWBC10", 0x5C},             //< AWB control
+    {"AWBC11", 0x5D},             //< AWB control
+    {"AWBC12", 0x5E},             //< AWB control
+    {"B_LMT", 0x5F},              //< AWB Gain control
+    {"R_LMT", 0x60},              //< AWB Gain control
+    {"G_LMT", 0x61},              //< AWB Gain control
+    {"LCC1", 0x62},               //< Lens correction option 1
+    {"LCC2", 0x63},               //< Lens correction option 2
+    {"LCC3", 0x64},               //< Lens correction option 3
+    {"LCC4", 0x65},               //< Lens correction option 4
+    {"LCC5", 0x66},               //< Lens correction option 5
+    {"MANU", 0x67},               //< Manual U value
+    {"MANV", 0x68},               //< Manual V value
+    {"GFIX", 0x69},               //< Fix gain control
+    {"GGAIN", 0x6A},              //< G channel AWB gain
+    {"DBLV", 0x6B},               //< PLL & regulator control
+    {"AWBCTR3", 0x6C},            //< AWB control 3
+    {"AWBCTR2", 0x6D},            //< AWB control 2
+    {"AWBCTR1", 0x6E},            //< AWB control 1
+    {"AWBCTR0", 0x6F},            //< AWB control 0
+    {"SCALING_XSC", 0x70},        //< Test pattern X scaling
+    {"SCALING_YSC", 0x71},        //< Test pattern Y scaling
+    {"SCALING_DCWCTR", 0x72},     //< DCW control
+    {"SCALING_PCLK_DIV", 0x73},   //< DSP scale control clock divide
+    {"REG74", 0x74},              //< Digital gain control
+    {"REG75", 0x75},              //< Edge control
+    {"REG76", 0x76},              //< Pixel correction
+    {"REG77", 0x77},              //< Offset de-noise
+    {"*RSVD*", 0x78},
+    {"*RSVD*", 0x79},
+    {"SLOP", 0x7A},               //< Gamma curve highest seg slope
+    {"GAMA1", 0x7B},              //< Gamma register base (1 of 15)
+    {"GAMA2", 0x7C},              //< Gamma register base (1 of 15)
+    {"GAMA3", 0x7D},              //< Gamma register base (1 of 15)
+    {"GAMA4", 0x7E},              //< Gamma register base (1 of 15)
+    {"GAMA5", 0x7F},              //< Gamma register base (1 of 15)
+    {"GAMA6", 0x80},              //< Gamma register base (1 of 15)
+    {"GAMA7", 0x81},              //< Gamma register base (1 of 15)
+    {"GAMA8", 0x82},              //< Gamma register base (1 of 15)
+    {"GAMA9", 0x83},              //< Gamma register base (1 of 15)
+    {"GAMA10", 0x84},              //< Gamma register base (1 of 15)
+    {"GAMA11", 0x85},              //< Gamma register base (1 of 15)
+    {"GAMA12", 0x86},              //< Gamma register base (1 of 15)
+    {"GAMA13", 0x87},              //< Gamma register base (1 of 15)
+    {"GAMA14", 0x88},              //< Gamma register base (1 of 15)
+    {"GAMA15", 0x89},              //< Gamma register base (1 of 15)
+    {"*RSVD*", 0x8A},
+    {"*RSVD*", 0x8B},
+    {"?RGB444", 0x8C},             //< RGB 444 control#if 0
+    {"*RSVD*", 0x8D},
+    {"*RSVD*", 0x8E},
+    {"*RSVD*", 0x8F},
+    {"*RSVD*", 0x90},
+    {"*RSVD*", 0x91},
+    {"DM_LNL", 0x92},             //< Dummy line LSB
+    {"DM_LNH", 0x93},             //< Dummy line LSB
+    {"LCC6", 0x94},               //< Lens correction option 6
+    {"LCC7", 0x95},               //< Lens correction option 7
+    {"*RSVD*", 0x96},
+    {"*RSVD*", 0x97},
+    {"*RSVD*", 0x98},
+    {"*RSVD*", 0x99},
+    {"*RSVD*", 0x9A},
+    {"*RSVD*", 0x9B},
+    {"*RSVD*", 0x9C},
+    {"BD50ST", 0x9D},
+    {"BD60ST", 0x9E},
+    {"HAECC1", 0x9F},             //< Histogram-based AEC/AGC ctrl 1
+    {"HAECC2", 0xA0},             //< Histogram-based AEC/AGC ctrl 2
+    {"DSPC3", 0xA1},
+    {"SCALING_PCLK_DELAY", 0xA2}, //< Scaling pixel clock delay
+    {"*RSVD*", 0xA3},
+    {"NT_CTRL", 0xA4},
+    {"AECGMAX", 0xA5},            //< 50 Hz banding step limit
+    {"LPH", 0xA6},             //< Histogram-based AEC/AGC ctrl 3
+    {"UPL", 0xA7},             //< Histogram-based AEC/AGC ctrl 4
+    {"TPL", 0xA8},             //< Histogram-based AEC/AGC ctrl 5
+    {"TPH", 0xA9},             //< Histogram-based AEC/AGC ctrl 6
+    {"NALG", 0xAA},             //< Histogram-based AEC/AGC ctrl 7
+    {"*RSVD*", 0xAB},            //< 60 Hz banding step limit
+    {"STR-OPT", 0xAC},
+    {"STR_R", 0xAD},
+    {"STR_G", 0xAE},
+    {"STR_B", 0xAF},
+    {"*RSVD*", 0xB0},
+    {"ABLC1", 0xB1},              //< ABLC enable
+    {"*RSVD*", 0xB2},
+    {"THL_ST", 0xB3},             //< ABLC target
+    {"*RSVD*", 0xB4},
+    {"THL_DLT", 0xB5},
+    {"*RSVD*", 0xB6},
+    {"*RSVD*", 0xB7},
+    {"*RSVD*", 0xB8},
+    {"*RSVD*", 0xB9},
+    {"*RSVD*", 0xBA},
+    {"*RSVD*", 0xBB},
+    {"*RSVD*", 0xBC},
+    {"*RSVD*", 0xBD},
+    {"AD-CHB", 0xBE},
+    {"AD-CHR", 0xBF},
+    {"AD-CHGb", 0xC0},
+    {"AD-CHRr", 0xC1},
+    {"*RSVD*", 0xC2},
+    {"*RSVD*", 0xC3},
+    {"*RSVD*", 0xC4},
+    {"*RSVD*", 0xC5},
+    {"*RSVD*", 0xC6},
+    {"*RSVD*", 0xC7},
+    {"*RSVD*", 0xC8},
+    {"SATCTR", 0xC9}              //< Saturation control
+
+};
+void print_ov767X_reg_name(Stream *pstream, uint16_t reg) {
+    for (uint16_t i=0; i < (sizeof(ov_reg_name_table)/sizeof(ov_reg_name_table[0])); i++) {
+      if (ov_reg_name_table[i].reg == reg) {
+      	pstream->print("(");
+      	pstream->print(ov_reg_name_table[i].reg_name);
+      	pstream->print(")");
+        break;
+      }
+    }
+}
+uint8_t OV7670::printRegs() {
+	bool verbose_prev = verboseDebug(false);
+	if (_debug == nullptr) return 0;
+	_debug->println("\n*** OV767X registers ***");
+    for (uint16_t ii=0; ii < (sizeof(ov_reg_name_table)/sizeof(ov_reg_name_table[0])); ii++) {
+		uint8_t reg_value = regRead(getID(), ov_reg_name_table[ii].reg, false);
+        _debug->print("(0x"); 
+        _debug->print(ii, HEX);
+        _debug->print("): (0x"); 
+        _debug->print(reg_value, HEX);
+        _debug->print(" - ");
+        _debug->print(reg_value, DEC);
+        _debug->print(")\t// ");
+        _debug->println(ov_reg_name_table[ii].reg_name);
+
+	}		
+	verboseDebug(verbose_prev);
+	return 0;
+}
+#else
+void print_ov767X_reg_name(Stream *_debug, uint16_t reg) {}
+uint8_t OV7670::printRegs() { return 0;}
+#endif 
+
+
+
 int OV7670::regWrite(uint8_t dev_addr, uint16_t reg_addr, uint8_t reg_data, bool wide_addr)
 {
+	if (_debug && _verbose) {
+		_debug->print("OV767X RegWrite reg: ");
+		_debug->print(reg_addr, HEX);
+		print_ov767X_reg_name(_debug, reg_addr);
+		_debug->print(" val:");
+		_debug->println(reg_data, HEX);
+	}
+
     _i2c->beginTransmission(dev_addr);
     uint8_t buf[3] = {(uint8_t) (reg_addr >> 8), (uint8_t) (reg_addr & 0xFF), reg_data};
     if (wide_addr == true) {
@@ -796,10 +1054,24 @@ uint8_t OV7670::regRead(uint8_t dev_addr, uint16_t reg_addr, bool wide_addr)
     while (_i2c->available()) {
         _i2c->read();
     }
+	if (_debug && _verbose) {
+		_debug->print("OV767X RegRead reg: ");
+		_debug->print(reg_addr, HEX);
+		print_ov767X_reg_name(_debug, reg_addr);
+		_debug->print(" val:");
+		_debug->println(reg_data, HEX);
+	}
     return reg_data;
 }
 
 void OV7670::debug(Stream &stream)
 {
   _debug = &stream;
+}
+
+bool OV7670::verboseDebug(bool fVerbose)
+{
+	bool verbose_prev = _verbose;
+	_verbose = fVerbose;
+	return verbose_prev;
 }

--- a/src/OV7670/ov767x.h
+++ b/src/OV7670/ov767x.h
@@ -30,7 +30,8 @@ class OV7670: public ImageSensor {
    private:
         int setWindow(uint16_t reg, uint16_t x, uint16_t y, uint16_t w, uint16_t h);
         Stream *_debug;
-        arduino::MbedI2C *_i2c;
+        bool _verbose = false;
+        WIRECLASS *_i2c;
         int regWrite(uint8_t dev_addr, uint16_t reg_addr, uint8_t reg_data, bool wide_addr = false);
         uint8_t regRead(uint8_t dev_addr, uint16_t reg_addr, bool wide_addr = false);
         static const uint8_t qqvga_regs[][2];
@@ -38,7 +39,7 @@ class OV7670: public ImageSensor {
         static const uint8_t rgb565_regs[][2];
 
    public:
-        OV7670(arduino::MbedI2C &i2c = CameraWire);
+        OV7670(WIRECLASS &i2c = CameraWire);
         int init();
         int reset();
         int getID() { return 0x21; };
@@ -55,7 +56,9 @@ class OV7670: public ImageSensor {
         int motionDetected() { return 0; };
         int setVerticalFlip(bool flip_enable);
         int setHorizontalMirror(bool mirror_enable);
+        uint8_t printRegs();
         void debug(Stream &stream);
+        bool verboseDebug(bool fVerbose);
 };
 
 class OV7675: public OV7670 {

--- a/src/arducam_dvp.h
+++ b/src/arducam_dvp.h
@@ -298,6 +298,14 @@ class ImageSensor {
         virtual void debug(Stream &stream) = 0;
 
         /**
+         * @brief prints the camera registers out to the debug stream.
+         * You can use this function to dump out the current register settings to the debug stream.
+         * @param stream Stream to output the debug information
+         * @return uint8_t 0 on success, non-zero on failure
+         */ 
+        virtual uint8_t printRegs() = 0;
+
+        /**
          * @brief Set the sensor in standby mode.
          * @note This has no effect on cameras that do not support standby mode.
          * @note None of the currently supported camera drivers implement this function.
@@ -387,6 +395,15 @@ private:
 };
 
 
+#if defined(ARDUINO_ARCH_MBED)
+#define WIRECLASS arduino::MbedI2C
+#define DELAYMS HAL_Delay
+#else
+#define WIRECLASS TwoWire
+#define DELAYMS delay
+#endif
+
+
 /**
  * @class Camera
  * @brief The main class for controlling a camera using the provided ImageSensor.
@@ -401,7 +418,7 @@ class Camera {
         int reset();             /// Reset the camera
         ScanResults<uint8_t> i2cScan(); /// Perform an I2C scan
         Stream *_debug;          /// Pointer to the debug stream
-        arduino::MbedI2C *_i2c;  /// Pointer to the I2C interface
+        WIRECLASS *_i2c;
         FrameBuffer *_framebuffer; /// Pointer to the frame buffer
         int setResolutionWithZoom(int32_t resolution, int32_t zoom_resolution, int32_t zoom_x, int32_t zoom_y);
 
@@ -638,9 +655,21 @@ class Camera {
          */
         void debug(Stream &stream);
 
+        /**
+         * @brief prints the camera registers out to the debug stream.
+         * You can use this function to dump out the current register settings to the debug stream.
+         * @param stream Stream to output the debug information
+         * @return uint8_t 0 on success, non-zero on failure
+         */ 
+        uint8_t printRegs();
+
 };
 
 #endif // __arducam_dvp_H
 
 /// The I2C bus used to communicate with the camera
+#if defined(ARDUINO_ARCH_MBED)
 extern arduino::MbedI2C CameraWire;
+#else
+#define CameraWire Wire
+#endif


### PR DESCRIPTION
Note; this PR resolves #5 

Fill in more of the Camera Class code from Nicla plus
There were several of the methods defined in the main camera
class that were not implemented. That is that the compiler
would complete, but the linker would fail.

It was a simple case of looking at the Camera code in the
Arduino Nicla Vision, to find the implementations.

I extended the class slightly, as most if not all of the
cameras, already had a debug method, so I added it
to the Camera class. I also added extended support
for allowing you to print out the current state
of the camera registers.

Some of the classes in particular HM01B0 and HM0360 had
not implemented the camera vertical flip and Horizontal
mirror, so put that in.

Also put in the change to add 32 bytes to the malloc
for the frame buffer as the code to make sure it was
on a 32 byte boundary could cause memory corruption

Plus I included two sketches I was using to test the code out on the Arduino GIGIA